### PR TITLE
Fixes unrecognised major/minor error on compiling

### DIFF
--- a/mptevents.c
+++ b/mptevents.c
@@ -8,6 +8,7 @@
 #include <sys/epoll.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <fcntl.h>
 #include <getopt.h>
 #include <stdarg.h>


### PR DESCRIPTION
When compiling it was failing with:

```
cc -O0 -g -Wall -Impt -DVERSION=\"1.3\"   -c -o mptevents.o mptevents.c
mptevents.c: In function ‘find_mptctl_device’:
mptevents.c:198:7: warning: implicit declaration of function ‘major’ [-Wimplicit-function-declaration]
   if (major(stbuf.st_rdev) == MISC_MAJOR_NUM &&
       ^~~~~
mptevents.c:199:6: warning: implicit declaration of function ‘minor’; did you mean ‘mknod’? [-Wimplicit-function-declaration]
     (minor(stbuf.st_rdev) == MPT2SAS_MINOR_NUM ||
      ^~~~~
      mknod
cc -O0 -g -Wall -Impt -DVERSION=\"1.3\"   -c -o mptparser.o mptparser.c
cc   mptevents.o mptparser.o   -o mptevents
/usr/bin/ld: mptevents.o: in function `find_mptctl_device':
/root/mptevents/mptevents.c:198: undefined reference to `major'
/usr/bin/ld: /root/mptevents/mptevents.c:199: undefined reference to `minor'
/usr/bin/ld: /root/mptevents/mptevents.c:200: undefined reference to `minor'
collect2: error: ld returned 1 exit status
make: *** [<builtin>: mptevents] Error 1
```

This change fixes that.